### PR TITLE
Better way of adding the Bioschemas?

### DIFF
--- a/src/main/js/components/compoundcard/Representations.js
+++ b/src/main/js/components/compoundcard/Representations.js
@@ -9,24 +9,29 @@ export default class Representations extends React.Component {
     render() {
         const naturalProduct = this.props.naturalProduct;
 
+        const divStyle = {
+  color: 'blue',
+  backgroundImage: 'url(' + imgUrl + ')',
+};
+
+        const bioschemas = {
+            "@context":"https://schema.org",
+            "@type":"MolecularEntity",
+            "name":" + naturalProduct.traditional_name + ",
+            "identifier":" + naturalProduct.lotus_id + ",
+            "iupacName":" + naturalProduct.iupac_name + ",
+            "inChIKey":" + naturalProduct.inchikey + ",
+            "url":"https://lotus.naturalproducts.net/compound/lotus_id/ + naturalProduct.lotus_id + ",
+            "inChI":" + naturalProduct.inchi +",
+            "smiles":" + (naturalProduct.smiles || naturalProduct.smiles2D) +"
+        };
+
         return (
             <Card className="compoundCardItem">
                 <Card.Body>
                     <Card.Title className="text-primary">Representations</Card.Title>
                     <br />
-                    <script type="application/ld+json" id="bioschemas">
-
-                            "@context":"https://schema.org",
-                            "@type":"MolecularEntity",
-                            "name":"{naturalProduct.traditional_name}",
-                            "identifier":"{naturalProduct.lotus_id}",
-                            "iupacName":"{naturalProduct.iupac_name}",
-                            "inChIKey":"{naturalProduct.inchikey}",
-                            "url":"https://lotus.naturalproducts.net/compound/lotus_id/{naturalProduct.lotus_id}",
-                            "inChI":"{naturalProduct.inchi}",
-                            "smiles":"{naturalProduct.smiles || naturalProduct.smiles2D }"
-
-                    </script>
+                    <script type="application/ld+json" id="bioschemas">{bioschemas}</script>
                     <Table responsive bordered hover size="sm" >
                         <tbody>
                         <tr key={"represent_id"}>


### PR DESCRIPTION
@mSorok, can you let me know if something like this works? On https://reactjs.org/docs/dom-elements.html#style there is the following example showing the complexity of the curly brackets, apparently, in React :)

```
const divStyle = {
  color: 'blue',
  backgroundImage: 'url(' + imgUrl + ')',
};

function HelloWorldComponent() {
  return <div style={divStyle}>Hello World!</div>;
}
```

But the Bioschemas uses additional quotes which further complicates it :(

But I'm hoping you now get an idea of the problem that needs to be solved...